### PR TITLE
Add support for api key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Add client as dependency:
 go get github.com/dexpro-solutions-gmbh/squeeze-go-client
 ```
 
+### Authentication
+
+Currently, only authentication via API key is supported. We will support for JWT based authentication
+in the future.
+
+```go
+
 ## Tests
 
 To run tests on this project, use these ENV variables to configure the Squeeze API to be used when testing:

--- a/api_queue.go
+++ b/api_queue.go
@@ -41,3 +41,26 @@ func (api *QueueApi) GetQueueSteps() (map[string]*QueueStepDto, *Error) {
 
 	return data, nil
 }
+
+func (api *QueueApi) GetQueueStep(stepName string) (*QueueStepDto, *Error) {
+	req, err := api.client.newRequest("GET", fmt.Sprintf("/queue/steps/%s", stepName))
+	if err != nil {
+		return nil, newErr(err)
+	}
+
+	res, err := api.client.http.Do(req)
+	if err != nil {
+		return nil, newApiErr(err, res)
+	}
+
+	if res.StatusCode != 200 {
+		return nil, newApiErr(fmt.Errorf("unexpected status code: %d", res.StatusCode), res)
+	}
+
+	var data QueueStepDto
+	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return nil, newApiErr(fmt.Errorf("unmarshaling json failed: %s", err), res)
+	}
+
+	return &data, nil
+}

--- a/api_queue.go
+++ b/api_queue.go
@@ -1,0 +1,43 @@
+package squeeze_go_client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type QueueApi struct {
+	client *Client
+}
+
+func newQueueApi(client *Client) *QueueApi {
+	return &QueueApi{client: client}
+}
+
+type QueueStepDto struct {
+	Name       string `json:"name"`
+	Count      int    `json:"count"`
+	ErrorCount int    `json:"errorCount"`
+}
+
+func (api *QueueApi) GetQueueSteps() (map[string]*QueueStepDto, *Error) {
+	req, err := api.client.newRequest("GET", "/queue/steps")
+	if err != nil {
+		return nil, newErr(err)
+	}
+
+	res, err := api.client.http.Do(req)
+	if err != nil {
+		return nil, newApiErr(err, res)
+	}
+
+	if res.StatusCode != 200 {
+		return nil, newApiErr(fmt.Errorf("unexpected status code: %d", res.StatusCode), res)
+	}
+
+	var data map[string]*QueueStepDto
+	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return nil, newApiErr(fmt.Errorf("unmarshaling json failed: %s", err), res)
+	}
+
+	return data, nil
+}

--- a/api_queue_test.go
+++ b/api_queue_test.go
@@ -13,3 +13,13 @@ func TestQueueApi_GetQueueSteps(t *testing.T) {
 	assert.NotNil(t, steps)
 	assert.NotEmpty(t, steps)
 }
+
+func TestQueueApi_GetQueueStep(t *testing.T) {
+	c := NewClient(getEnvVal("SQZ_BASE_PATH"))
+	c.ApiKey = getEnvApiKey(t)
+	step, e := c.Queue.GetQueueStep("Validation")
+	assert.Nil(t, e)
+	assert.NotNil(t, step)
+	assert.NotEmpty(t, step)
+	assert.Equal(t, "Validation", step.Name)
+}

--- a/api_queue_test.go
+++ b/api_queue_test.go
@@ -1,0 +1,15 @@
+package squeeze_go_client
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestQueueApi_GetQueueSteps(t *testing.T) {
+	c := NewClient(getEnvVal("SQZ_BASE_PATH"))
+	c.ApiKey = getEnvApiKey(t)
+	steps, e := c.Queue.GetQueueSteps()
+	assert.Nil(t, e)
+	assert.NotNil(t, steps)
+	assert.NotEmpty(t, steps)
+}

--- a/client.go
+++ b/client.go
@@ -9,6 +9,9 @@ type Client struct {
 	// basePath is the base path of the Squeeze API, example: https://tenant.squeeze.one/api/v2
 	basePath string
 
+	// ApiKey is used to authenticate with Squeeze
+	ApiKey string
+
 	// http is the HTTP client used to make requests
 	http *http.Client
 
@@ -26,5 +29,14 @@ func NewClient(basePath string) *Client {
 }
 
 func (c *Client) newRequest(method string, path string) (*http.Request, error) {
-	return http.NewRequest(method, fmt.Sprintf("%s%s", c.basePath, path), nil)
+	request, err := http.NewRequest(method, fmt.Sprintf("%s%s", c.basePath, path), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.ApiKey != "" {
+		request.Header.Set("X-Api-Key", c.ApiKey)
+	}
+
+	return request, err
 }

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	http *http.Client
 
 	Public *PublicApi
+	Queue  *QueueApi
 }
 
 func NewClient(basePath string) *Client {
@@ -24,6 +25,7 @@ func NewClient(basePath string) *Client {
 	c.http = &http.Client{}
 
 	c.Public = newPublicApi(c)
+	c.Queue = newQueueApi(c)
 
 	return c
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,19 +1,9 @@
 package squeeze_go_client
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 )
-
-func getEnvVal(key string) string {
-	if val, ok := os.LookupEnv(key); !ok {
-		panic(fmt.Sprintf("environment variable %s is not set", key))
-	} else {
-		return val
-	}
-}
 
 func TestPublicApi_GetHealth(t *testing.T) {
 	c := NewClient(getEnvVal("SQZ_BASE_PATH"))

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,26 @@
+package squeeze_go_client
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// getEnvVal either returns the value of the ENV var with the given name or panics if it is not set.
+func getEnvVal(key string) string {
+	if val, ok := os.LookupEnv(key); !ok {
+		panic(fmt.Sprintf("environment variable %s is not set", key))
+	} else {
+		return val
+	}
+}
+
+// getEnvApiKey either returns the value of the ENV var SQZ_KEY or skips the test if it is not set.
+func getEnvApiKey(t *testing.T) string {
+	if val, ok := os.LookupEnv("SQZ_KEY"); !ok {
+		t.Skip("environment variable SQZ_KEY is not set")
+		return ""
+	} else {
+		return val
+	}
+}


### PR DESCRIPTION
This PR will add crude support for api key based authentication.

In order to test this, I also add two api methods which require proper authentication.

Currently these will be skipped in the CI pipeline because no API key is set. This is intentional because I do not yet want to add that to the CI. Once a proper test system is set up, I will add the API key which will then allow us to test all endpoint.